### PR TITLE
Hexagonix v1.0

### DIFF
--- a/Apps.sh
+++ b/Apps.sh
@@ -104,7 +104,7 @@ do
 
     echo " > Building Andromeda application $(basename $h .asm)..." >> $LOG
 
-    fasm $h $BUILD_DIRECTORY/bin/`basename $h .asm` -d $COMMON_FLAGS >> $LOG || umount
+    fasm $h $BUILD_DIRECTORY/usr/bin/`basename $h .asm` -d $COMMON_FLAGS >> $LOG || umount
 
     echo -e " [\e[32mOk\e[0m]"
 
@@ -150,6 +150,6 @@ echo -e "hx and hx modules are licensed under BSD-3-Clause and comes with no war
 
 }
 
-export APPS_MOD_VERSION="6.1.0"
+export APPS_MOD_VERSION="6.3.0"
 
 main $1

--- a/ash/ash.asm
+++ b/ash/ash.asm
@@ -479,6 +479,11 @@ shellStart:
 
     pop esi
 
+;; Protect the arguments from Shell.checkShebang before it opens the
+;; resolved command's own file into appFileBuffer
+
+    call Shell.protectArguments
+
 ;; Resolve the command name against PATH if it isn't already valid as
 ;; given, then check for a "#!name" shebang on the resolved file
 

--- a/ash/ash.asm
+++ b/ash/ash.asm
@@ -73,7 +73,7 @@ use32
 include "HAPP.s" ;; Here is a structure for the HAPP header
 
 ;; Instance | Structure | Architecture | Version | Subversion | Entry Point | Image type
-appHeader headerHAPP HAPP.Architectures.i386, 1, 4, shellStart, 01h
+appHeader headerHAPP HAPP.Architectures.i386, 1, 7, shellStart, 01h
 
 ;;************************************************************************************
 
@@ -98,8 +98,8 @@ ASHError           = VERMELHO
 ASHLimitReached    = AMARELO_ANDROMEDA
 ASHSuccess         = VERDE
 
-VERSION             equ "5.2.0"
-compatibleHexagonix equ "Dormin"
+VERSION             equ "5.3.0"
+compatibleHexagonix equ "Mineru"
 
 ;;**************************
 
@@ -237,7 +237,7 @@ shellStart:
 
     hx.syscall hx.fileExists
 
-    jc .start ;; Not a file (or some other argument shape); interactive as usual
+    jc .start ;; Not a file (or some other argument shape). Interactive as usual
 
     mov esi, [commandLine]
 
@@ -495,7 +495,7 @@ shellStart:
 
     jc .noShebang
 
-;; ESI = shell name from the shebang line; run that shell with the
+;; ESI = shell name from the shebang line. Run that shell with the
 ;; resolved script as its own argument, ignoring any arguments this
 ;; command line itself may have had
 

--- a/ash/ash.asm
+++ b/ash/ash.asm
@@ -684,6 +684,8 @@ shellStart:
 
     mov esi, ASH.volume.hd0
 
+    xor ecx, ecx
+
     hx.syscall hx.open
 
     putNewLine
@@ -695,6 +697,8 @@ shellStart:
     systemLog ASH.verboseDeprecatedInterface, 00h, Log.Priorities.p4
 
     mov esi, ASH.volume.hd1
+
+    xor ecx, ecx
 
     hx.syscall hx.open
 
@@ -708,6 +712,8 @@ shellStart:
 
     mov esi, ASH.volume.hd2
 
+    xor ecx, ecx
+
     hx.syscall hx.open
 
     putNewLine
@@ -719,6 +725,8 @@ shellStart:
     systemLog ASH.verboseDeprecatedInterface, 00h, Log.Priorities.p4
 
     mov esi, ASH.volume.hd3
+
+    xor ecx, ecx
 
     hx.syscall hx.open
 

--- a/ash/ash.asm
+++ b/ash/ash.asm
@@ -82,6 +82,7 @@ include "Estelar/estelar.s"
 include "errors.s"
 include "log.s"
 include "macros.s"
+include "shell.s"
 
 ;;************************************************************************************
 ;;
@@ -162,6 +163,8 @@ db "ver", 0
 db "help", 0
 .cd:
 db "cd", 0
+.set:
+db "set", 0
 
 ;;**************************
 
@@ -207,15 +210,42 @@ db "You can find documentation for mount using 'man mount' anytime.", 0
 currentVolume: times 3 db 0
 
 ASH.background: db 0 ;; Set to 1 when the current command line ends in "&"
+ASH.resolvedPath: dd 0 ;; Command path after Shell.resolveCommandPath, across the shebang check
+
+commandLine: dd 0
 
 ;;************************************************************************************
 
 shellStart:
 
+    mov [commandLine], edi
+
     systemLog ASH.verboseStartingASH, 00h, Log.Priorities.p4
     systemLog ASH.verboseVersionASH, 00h, Log.Priorities.p4
     systemLog ASH.verboseAuthors, 00h, Log.Priorities.p4
     systemLog ASH.verboseCopyright, 00h, Log.Priorities.p4
+
+    mov esi, [commandLine]
+
+    cmp byte[esi], 0
+    je .start
+
+;; Launched with a single existing file as an argument: run it as a
+;; script instead of starting an interactive prompt. This is how a
+;; shebang dispatch from Shell.checkShebang hands a script off to the
+;; shell named on its "#!" line
+
+    hx.syscall hx.fileExists
+
+    jc .start ;; Not a file (or some other argument shape); interactive as usual
+
+    mov esi, [commandLine]
+
+    call Shell.runScriptFile
+
+    jmp .finishShell
+
+.start:
 
 ;; Start console configuration
 
@@ -228,6 +258,10 @@ shellStart:
     call showBanner
 
     fputs ASH.welcome
+
+    putNewLine
+
+    call Shell.loadRc
 
 ;;************************************************************************************
 
@@ -308,6 +342,14 @@ shellStart:
     hx.syscall hx.compareWordsString
 
     jc .commandCD
+
+    ;; SET command
+
+    mov edi, ASH.commands.set
+
+    hx.syscall hx.compareWordsString
+
+    jc .commandSET
 
 ;;************************************************************************************
 
@@ -437,6 +479,37 @@ shellStart:
 
     pop esi
 
+;; Resolve the command name against PATH if it isn't already valid as
+;; given, then check for a "#!name" shebang on the resolved file
+
+    call Shell.resolveCommandPath
+
+    mov [ASH.resolvedPath], esi
+
+    call Shell.checkShebang
+
+    jc .noShebang
+
+;; ESI = shell name from the shebang line; run that shell with the
+;; resolved script as its own argument, ignoring any arguments this
+;; command line itself may have had
+
+    mov edi, dword[ASH.resolvedPath]
+
+    mov eax, 1
+
+    stc
+
+    hx.syscall hx.exec
+
+    jc .failedToExecute
+
+    jmp .getCommand
+
+.noShebang:
+
+    mov esi, dword[ASH.resolvedPath]
+
     cmp byte[ASH.background], 1
     je .loadApplicationBackground
 
@@ -526,6 +599,16 @@ shellStart:
     mov ecx, 01h
 
     call changeColor
+
+    jmp .getCommand
+
+.commandSET:
+
+    add esi, 03h
+
+    hx.syscall hx.trimString
+
+    call Shell.handleSet
 
     jmp .getCommand
 

--- a/config/Data/Interfaces.asm
+++ b/config/Data/Interfaces.asm
@@ -129,7 +129,7 @@ db "System build: ", 0
 .systemType:
 db "System type (arch):", 0
 .systemModel:
-db " x86", 10, 0
+db " i386", 10, 0
 .updatePackage:
 db "Update package installed: ", 0
 .copyright:

--- a/config/Data/Interfaces.asm
+++ b/config/Data/Interfaces.asm
@@ -121,15 +121,15 @@ infoInterfaceData:
 .intro:
 db "Detailed Information of the Hexagonix Operating System", 0
 .systemName:
-db "Installed Operating System name: ", 0
+db "Operating System: ", 0
 .systemVersion:
-db "Operating System version: ", 0
+db "System version: ", 0
 .systemBuild:
-db "Operating System build: ", 0
+db "System build: ", 0
 .systemType:
-db "Operating System type:", 0
+db "System type (arch):", 0
 .systemModel:
-db " 32-bit", 10, 0
+db " x86", 10, 0
 .updatePackage:
 db "Update package installed: ", 0
 .copyright:
@@ -139,7 +139,7 @@ db "All rights reserved.", 0
 .hardwareIntro:
 db "Hardware information for this device", 0
 .mainProcessor:
-db "Installed processor (considering only the main processor):", 0
+db "Installed processor:", 0
 .processorNumber:
 db "1) ", 0
 .processorOperationMode:

--- a/config/Hexagonix/hardware.asm
+++ b/config/Hexagonix/hardware.asm
@@ -73,6 +73,8 @@ exibirProcessadorInstalado:
 
     mov esi, Hexagon.LibASM.Dev.processors.proc0
 
+    xor ecx, ecx
+
     hx.syscall hx.open
 
     cmp byte [esi], 0

--- a/config/Interfaces/Serial.asm
+++ b/config/Interfaces/Serial.asm
@@ -184,6 +184,8 @@ match =YES, VERBOSE
 
     mov esi, Hexagon.LibASM.Dev.serialPorts.com1
 
+    xor ecx, ecx
+
     hx.syscall hx.open
 
     jc openError
@@ -224,6 +226,8 @@ match =YES, VERBOSE
 }
 
     mov esi, Hexagon.LibASM.Dev.serialPorts.com1
+
+    xor ecx, ecx
 
     hx.syscall hx.open
 

--- a/config/Interfaces/Themes.asm
+++ b/config/Interfaces/Themes.asm
@@ -173,11 +173,15 @@ configureConsoles:
 
     mov esi, Hexagon.LibASM.Dev.video.tty1 ;; Open the secondary console
 
+    xor ecx, ecx
+
     hx.syscall hx.open ;; Open the device
 
     hx.syscall hx.clearConsole
 
     mov esi, Hexagon.LibASM.Dev.video.tty0 ;; Reopen the default console
+
+    xor ecx, ecx
 
     hx.syscall hx.open ;; Open the device
 

--- a/config/config.asm
+++ b/config/config.asm
@@ -73,7 +73,7 @@ use32
 include "HAPP.s" ;; Here is a structure for the HAPP header
 
 ;; Instance | Structure | Architecture | Version | Subversion | Entry Point | Image type
-appHeader headerHAPP HAPP.Architectures.i386, 1, 00, applicationStart, 01h
+appHeader headerHAPP HAPP.Architectures.i386, 1, 7, applicationStart, 01h
 
 ;;************************************************************************************
 

--- a/config/version.s
+++ b/config/version.s
@@ -66,6 +66,6 @@
 ;;
 ;; $HexagonixOS$
 
-VERSION             equ "5.2.2"
+VERSION             equ "5.2.3"
 toolsVersion        equ "3.0.0"
-compatibleHexagonix equ "System I"
+compatibleHexagonix equ "Mineru"

--- a/config/version.s
+++ b/config/version.s
@@ -66,6 +66,6 @@
 ;;
 ;; $HexagonixOS$
 
-VERSION             equ "5.2.3"
-toolsVersion        equ "3.0.0"
+VERSION             equ "5.3.0"
+toolsVersion        equ "3.1.0"
 compatibleHexagonix equ "Mineru"

--- a/config/version.s
+++ b/config/version.s
@@ -66,6 +66,6 @@
 ;;
 ;; $HexagonixOS$
 
-VERSION             equ "5.3.0"
+VERSION             equ "5.3.1"
 toolsVersion        equ "3.1.0"
 compatibleHexagonix equ "Mineru"

--- a/dossh/dossh.asm
+++ b/dossh/dossh.asm
@@ -73,7 +73,7 @@ use32
 include "HAPP.s" ;; Here is a structure for the HAPP header
 
 ;; Instance | Structure | Architecture | Version | Subversion | Entry Point | Image type
-appHeader headerHAPP HAPP.Architectures.i386, 1, 3, shellStart, 01h
+appHeader headerHAPP HAPP.Architectures.i386, 1, 7, shellStart, 01h
 
 ;;************************************************************************************
 
@@ -90,8 +90,8 @@ include "shell.s"
 ;;
 ;;************************************************************************************
 
-VERSION             equ "0.2.1"
-compatibleHexagonix equ "Dormin"
+VERSION             equ "0.2.2"
+compatibleHexagonix equ "Mineru"
 
 ;;**************************
 
@@ -220,7 +220,7 @@ shellStart:
 
     hx.syscall hx.fileExists
 
-    jc .start ;; Not a file (or some other argument shape); interactive as usual
+    jc .start ;; Not a file (or some other argument shape). Interactive as usual
 
     mov esi, [commandLine]
 
@@ -260,7 +260,7 @@ getCommand:
 
     hx.syscall hx.trimString ;; Remove extra spaces
 
-    cmp byte[esi], 0 ;; Nenhum comando inserido
+    cmp byte[esi], 0 ;; No command inserted
     je getCommand
 
 ;; Compare with available internal commands
@@ -411,7 +411,7 @@ loadImage:
 
     jc .noShebang
 
-;; ESI = shell name from the shebang line; run that shell with the
+;; ESI = shell name from the shebang line. Run that shell with the
 ;; resolved script as its own argument, ignoring any arguments this
 ;; command line itself may have had
 

--- a/dossh/dossh.asm
+++ b/dossh/dossh.asm
@@ -623,6 +623,8 @@ commandTYPE:
     mov esi, edi
     mov edi, appFileBuffer
 
+    xor ecx, ecx
+
     hx.syscall hx.open
 
     jc fileNotFound

--- a/dossh/dossh.asm
+++ b/dossh/dossh.asm
@@ -395,6 +395,11 @@ loadImage:
 
     pop esi
 
+;; Protect the arguments from Shell.checkShebang before it opens the
+;; resolved command's own file into appFileBuffer
+
+    call Shell.protectArguments
+
 ;; Resolve the command name against PATH if it isn't already valid as
 ;; given, then check for a "#!name" shebang on the resolved file
 

--- a/dossh/dossh.asm
+++ b/dossh/dossh.asm
@@ -82,6 +82,7 @@ include "Estelar/estelar.s"
 include "errors.s"
 include "log.s"
 include "macros.s"
+include "shell.s"
 
 ;;************************************************************************************
 ;;
@@ -168,6 +169,8 @@ db "dir", 0
 db "type", 0
 .cd:
 db "cd", 0
+.set:
+db "set", 0
 
 ;; Regarding the help and ver commands
 
@@ -190,14 +193,42 @@ db " EXIT - Terminate this DOSsh session.", 10, 0
 remainingList: dd ?
 currentFile:   dd ' '
 
+DOSsh.resolvedPath: dd 0 ;; Command path after Shell.resolveCommandPath, across the shebang check
+
+commandLine: dd 0
+
 ;;************************************************************************************
 
 shellStart:
+
+    mov [commandLine], edi
 
     systemLog DOSsh.verboseStartingDOSsh, 00h, Log.Priorities.p4
     systemLog DOSsh.verboseDOSshVersion, 00h, Log.Priorities.p4
     systemLog DOSsh.verboseAuthor, 00h, Log.Priorities.p4
     systemLog DOSsh.verboseCopyright, 00h, Log.Priorities.p4
+
+    mov esi, [commandLine]
+
+    cmp byte[esi], 0
+    je .start
+
+;; Launched with a single existing file as an argument: run it as a
+;; script instead of starting an interactive prompt. This is how a
+;; shebang dispatch from Shell.checkShebang hands a script off to the
+;; shell named on its "#!" line
+
+    hx.syscall hx.fileExists
+
+    jc .start ;; Not a file (or some other argument shape); interactive as usual
+
+    mov esi, [commandLine]
+
+    call Shell.runScriptFile
+
+    jmp finishShell
+
+.start:
 
 ;; Start console configuration
 
@@ -206,6 +237,10 @@ shellStart:
     hx.syscall hx.clearConsole
 
     fputs DOSsh.starting
+
+    putNewLine
+
+    call Shell.loadRc
 
 ;;************************************************************************************
 
@@ -286,6 +321,14 @@ getCommand:
 
     jc commandCD
 
+    ;; SET command
+
+    mov edi, DOSsh.commands.set
+
+    hx.syscall hx.compareWordsString
+
+    jc commandSET
+
 ;;************************************************************************************
 
 loadImage:
@@ -351,6 +394,37 @@ loadImage:
     hx.syscall hx.trimString
 
     pop esi
+
+;; Resolve the command name against PATH if it isn't already valid as
+;; given, then check for a "#!name" shebang on the resolved file
+
+    call Shell.resolveCommandPath
+
+    mov [DOSsh.resolvedPath], esi
+
+    call Shell.checkShebang
+
+    jc .noShebang
+
+;; ESI = shell name from the shebang line; run that shell with the
+;; resolved script as its own argument, ignoring any arguments this
+;; command line itself may have had
+
+    mov edi, dword[DOSsh.resolvedPath]
+
+    mov eax, 1
+
+    stc
+
+    hx.syscall hx.exec
+
+    jc .failedToExecute
+
+    jmp getCommand
+
+.noShebang:
+
+    mov esi, dword[DOSsh.resolvedPath]
 
     mov eax, edi
 
@@ -512,6 +586,18 @@ commandCD:
 .errorChangingDirectory:
 
     fputs DOSsh.errorChangingDirectory
+
+    jmp getCommand
+
+;;************************************************************************************
+
+commandSET:
+
+    add esi, 03h
+
+    hx.syscall hx.trimString
+
+    call Shell.handleSet
 
     jmp getCommand
 

--- a/gfont/gfont.asm
+++ b/gfont/gfont.asm
@@ -188,7 +188,7 @@ validateFont:
     cmp byte[edi+3], "T"
     jne .invalidHFNT
 
-.verificarTamanho:
+.checkSize:
 
     hx.syscall hx.fileExists
 
@@ -231,7 +231,7 @@ validateFont:
 ;;
 ;;************************************************************************************
 
-VERSION equ "2.7.0"
+VERSION equ "2.7.1"
 
 gfont:
 

--- a/gfont/gfont.asm
+++ b/gfont/gfont.asm
@@ -158,10 +158,17 @@ finish:
 
 ;;************************************************************************************
 
+;; Only the first 4 bytes (the "HFNT" magic, checked below) are looked at
+;; here. The real size check comes right after, but that's too late to
+;; protect this read itself, so cap it independently rather than pulling in
+;; the rest of a possibly much larger file first
+
 validateFont:
 
     mov esi, [fontFile]
     mov edi, appFileBuffer
+
+    mov ecx, 128
 
     hx.syscall hx.open
 

--- a/lyoko/lyoko.asm
+++ b/lyoko/lyoko.asm
@@ -269,6 +269,8 @@ LyokoIDE:
 
     mov edi, appFileBuffer ;; Loading address
 
+    xor ecx, ecx
+
     hx.syscall hx.open
 
     mov esi, filename
@@ -349,6 +351,8 @@ LyokoIDE:
 ;; Print other lines
 
     mov esi, Hexagon.LibASM.Dev.video.tty1
+
+    xor ecx, ecx
 
     hx.syscall hx.open
 
@@ -448,6 +452,8 @@ LyokoIDE:
     hx.syscall hx.updateScreen
 
     mov esi, Hexagon.LibASM.Dev.video.tty0
+
+    xor ecx, ecx
 
     hx.syscall hx.open
 
@@ -2287,11 +2293,15 @@ clearVideoBuffer:
 
     mov esi, Hexagon.LibASM.Dev.video.tty1
 
+    xor ecx, ecx
+
     hx.syscall hx.open
 
     hx.syscall hx.clearConsole
 
     mov esi, Hexagon.LibASM.Dev.video.tty0
+
+    xor ecx, ecx
 
     hx.syscall hx.open
 

--- a/power/power.asm
+++ b/power/power.asm
@@ -73,7 +73,7 @@ use32
 include "HAPP.s" ;; Here is a structure for the HAPP header
 
 ;; Instance | Structure | Architecture | Version | Subversion | Entry Point | Image type
-appHeader headerHAPP HAPP.Architectures.i386, 1, 00, applicationStart, 01h
+appHeader headerHAPP HAPP.Architectures.i386, 1, 7, applicationStart, 01h
 
 ;;************************************************************************************
 
@@ -263,7 +263,7 @@ finish:
 ;;************************************************************************************
 
 SHUTDOWN equ "/sbin/shutdown"
-VERSION  equ "1.10.0"
+VERSION  equ "1.10.1"
 
 COLOR_HIGHLIGHT = HEXAGONIX_BLOSSOM_AZUL_ANDROMEDA
 COLOR_FONT      = HEXAGONIX_CLASSICO_BRANCO

--- a/power/power.asm
+++ b/power/power.asm
@@ -262,7 +262,7 @@ finish:
 ;;
 ;;************************************************************************************
 
-SHUTDOWN equ "shutdown"
+SHUTDOWN equ "/sbin/shutdown"
 VERSION  equ "1.10.0"
 
 COLOR_HIGHLIGHT = HEXAGONIX_BLOSSOM_AZUL_ANDROMEDA

--- a/quartzo/quartzo.asm
+++ b/quartzo/quartzo.asm
@@ -197,6 +197,8 @@ Quartzo:
 
     mov edi, appFileBuffer ;; Loading address
 
+    xor ecx, ecx
+
     hx.syscall hx.open
 
     mov esi, filename
@@ -275,6 +277,8 @@ Quartzo:
 ;; Print other lines
 
     mov esi, Hexagon.LibASM.Dev.video.tty1
+
+    xor ecx, ecx
 
     hx.syscall hx.open
 
@@ -356,6 +360,8 @@ Quartzo:
     hx.syscall hx.updateScreen
 
     mov esi, Hexagon.LibASM.Dev.video.tty0
+
+    xor ecx, ecx
 
     hx.syscall hx.open
 
@@ -717,11 +723,15 @@ restartVideoBuffer:
 
     mov esi, Hexagon.LibASM.Dev.video.tty1
 
+    xor ecx, ecx
+
     hx.syscall hx.open
 
     hx.syscall hx.clearConsole
 
     mov esi, Hexagon.LibASM.Dev.video.tty0
+
+    xor ecx, ecx
 
     hx.syscall hx.open
 

--- a/serial/serial.asm
+++ b/serial/serial.asm
@@ -113,6 +113,8 @@ applicationStart:
 
     mov esi, serial.deviceName
 
+    xor ecx, ecx
+
     hx.syscall hx.open
 
     jc openError


### PR DESCRIPTION
- **Andromeda Apps (Hexagonix-Andromeda environment)**:
  - Changes to the environment shells (`ash` and `dossh`):
    - New shell-script execution feature; scripts must have a `#!/bin/ash` identifier (or the name of another compatible shell) at the start of the file;
    - New command to get and set environment variables;
    - Executable lookup using the `PATH` variable, allowing the execution of utilities that are segregated in other system directories;
    - Ability to start a process in the background, using `&`:
      - For example, starting the `clock` utility in the background: `clock &`;
  - Changes to the `config` utility:
    - Adaptation of configuration files to use the `/etc` directory as their base directory;
    - Changes to some of the utility's messages;
  - Moves utilities from `/` to `/bin`;